### PR TITLE
:bug: DependaBotの設定ファイルのミスを修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    reviewers: "gakuseiBOT/HP-Dev"
+    reviewers: [ "gakuseiBOT/HP-Dev" ]


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change modifies the format of the `reviewers` field to use an array instead of a string.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R12): Changed `reviewers` from a string to an array to ensure proper formatting.Reviewersの欄が配列型になっていない問題を修正