### PR TITLE
🔨 Improve Vercel workflow with label-based deployment conditions

### DIFF
--- a/.github/workflows/VercelPreview.yaml
+++ b/.github/workflows/VercelPreview.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - main
+  label:
+    types: [created, deleted]
 jobs:
     deployment:
         runs-on: ubuntu-latest
@@ -12,20 +14,45 @@ jobs:
             url: ${{ steps.get_release_url.outputs.release_url }}
         steps:
         - uses: actions/checkout@v4
-        - name: Install Vercel CLI
+        - name: Get PR labels
+          id: labels
+          shell: bash
+          env:
+            GH_REPO: ${{ github.repository }}
+            GH_TOKEN: ${{ github.token }}
+            PR_NUMBER: ${{ github.event.number }}
+          run: |
+            json=$(gh pr view "$PR_NUMBER" --json labels | jq -c '.labels|map(.name)')
+            echo "json=$json" >> "$GITHUB_OUTPUT"
+        - if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
+          name: Install Vercel CLI
           run: npm install -g vercel
         - name: Link Vercel Project
-          run: vercel link --token=${{secrets.VERCEL_TOKEN}} --project ${{secrets.VERCEL_PROJECT}} --yes
+          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
+          run: vercel link --token=${{secrets.VERCEL_TOKEN}} --project ${{vars.VERCEL_PROJECT}} --yes
         - name: Deploy with Vercel
+          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
           run: vercel deploy --target=staging --token=${{secrets.VERCEL_TOKEN}} >deployment-url.txt 2>error.txt
         - name: Set release url
+          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
           id: get_release_url
           run: echo release_url=$(cat deployment-url.txt) >> $GITHUB_OUTPUT
         - name: Comment on PR
+          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
           run: |
             cat  << EOF > comment.md
             ## :rocket: Preview Deployment
             [Preview Deployment](${{ steps.get_release_url.outputs.release_url }})
+            EOF
+            gh pr comment ${{ github.event.number }} --body-file comment.md
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - name: Comment on PR
+          if: ${{contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate')}}
+          run: |
+            cat  << EOF > comment.md
+            ## :rocket: Preview Deployment
+            Deployment skipped due to label(s) - dependencies, documentation, duplicate
             EOF
             gh pr comment ${{ github.event.number }} --body-file comment.md
           env:

--- a/.github/workflows/VercelPreview.yaml
+++ b/.github/workflows/VercelPreview.yaml
@@ -6,54 +6,66 @@ on:
   label:
     types: [created, deleted]
 jobs:
-    deployment:
-        runs-on: ubuntu-latest
-        concurrency: Preview
-        environment:
-            name: Preview
-            url: ${{ steps.get_release_url.outputs.release_url }}
-        steps:
-        - uses: actions/checkout@v4
-        - name: Get PR labels
-          id: labels
-          shell: bash
-          env:
-            GH_REPO: ${{ github.repository }}
-            GH_TOKEN: ${{ github.token }}
-            PR_NUMBER: ${{ github.event.number }}
-          run: |
-            json=$(gh pr view "$PR_NUMBER" --json labels | jq -c '.labels|map(.name)')
-            echo "json=$json" >> "$GITHUB_OUTPUT"
-        - if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
-          name: Install Vercel CLI
-          run: npm install -g vercel
-        - name: Link Vercel Project
-          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
-          run: vercel link --token=${{secrets.VERCEL_TOKEN}} --project ${{vars.VERCEL_PROJECT}} --yes
-        - name: Deploy with Vercel
-          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
-          run: vercel deploy --target=staging --token=${{secrets.VERCEL_TOKEN}} >deployment-url.txt 2>error.txt
-        - name: Set release url
-          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
-          id: get_release_url
-          run: echo release_url=$(cat deployment-url.txt) >> $GITHUB_OUTPUT
-        - name: Comment on PR
-          if: ${{!(contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate'))}}
-          run: |
-            cat  << EOF > comment.md
-            ## :rocket: Preview Deployment
-            [Preview Deployment](${{ steps.get_release_url.outputs.release_url }})
-            EOF
-            gh pr comment ${{ github.event.number }} --body-file comment.md
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - name: Comment on PR
-          if: ${{contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate')}}
-          run: |
-            cat  << EOF > comment.md
-            ## :rocket: Preview Deployment
-            Deployment skipped due to label(s) - dependencies, documentation, duplicate
-            EOF
-            gh pr comment ${{ github.event.number }} --body-file comment.md
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  checkLabels:
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.labels.outputs.test }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get PR labels
+      id: labels
+      shell: bash
+      env:
+        GH_REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        json=$(gh pr view "$PR_NUMBER" --json labels | jq -c '.labels|map(.name)')
+        echo "json=$json" >> "$GITHUB_OUTPUT"
+  deployment:
+    needs: checkLabels
+    if: ${{ !(contains(fromJSON(needs.job1.outputs.output1), 'dependencies') || contains(fromJSON(needs.job1.outputs.output1), 'documentation') || contains(fromJSON(needs.job1.outputs.output1), 'duplicate')) }}
+    runs-on: ubuntu-latest
+    concurrency: Preview
+    environment:
+        name: Preview
+        url: ${{ steps.get_release_url.outputs.release_url }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get PR labels
+      id: labels
+      shell: bash
+      env:
+        GH_REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        json=$(gh pr view "$PR_NUMBER" --json labels | jq -c '.labels|map(.name)')
+        echo "json=$json" >> "$GITHUB_OUTPUT"
+    - name: Install Vercel CLI
+      run: npm install -g vercel
+    - name: Link Vercel Project
+      run: vercel link --token=${{secrets.VERCEL_TOKEN}} --project ${{vars.VERCEL_PROJECT}} --yes
+    - name: Deploy with Vercel
+      run: vercel deploy --target=staging --token=${{secrets.VERCEL_TOKEN}} >deployment-url.txt 2>error.txt
+    - name: Set release url
+      id: get_release_url
+      run: echo release_url=$(cat deployment-url.txt) >> $GITHUB_OUTPUT
+    - name: Comment on PR
+      run: |
+        cat  << EOF > comment.md
+        ## :rocket: Preview Deployment
+        [Preview Deployment](${{ steps.get_release_url.outputs.release_url }})
+        EOF
+        gh pr comment ${{ github.event.number }} --body-file comment.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Comment on PR
+      run: |
+        cat  << EOF > comment.md
+        ## :rocket: Preview Deployment
+        Deployment skipped due to label(s) - dependencies, documentation, duplicate
+        EOF
+        gh pr comment ${{ github.event.number }} --body-file comment.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/VercelPreview.yaml
+++ b/.github/workflows/VercelPreview.yaml
@@ -24,7 +24,7 @@ jobs:
         echo "json=$json" >> "$GITHUB_OUTPUT"
   deployment:
     needs: checkLabels
-    if: ${{ !(contains(fromJSON(needs.job1.outputs.output1), 'dependencies') || contains(fromJSON(needs.job1.outputs.output1), 'documentation') || contains(fromJSON(needs.job1.outputs.output1), 'duplicate')) }}
+    if: ${{ !(contains(fromJSON(needs.checkLabels.outputs.output1), 'dependencies') || contains(fromJSON(needs.checkLabels.outputs.output1), 'documentation') || contains(fromJSON(needs.checkLabels.outputs.output1), 'duplicate')) }}
     runs-on: ubuntu-latest
     concurrency: Preview
     environment:

--- a/.github/workflows/VercelPreview.yaml
+++ b/.github/workflows/VercelPreview.yaml
@@ -22,6 +22,16 @@ jobs:
       run: |
         json=$(gh pr view "$PR_NUMBER" --json labels | jq -c '.labels|map(.name)')
         echo "json=$json" >> "$GITHUB_OUTPUT"
+    - name: Comment on PR
+      if: ${{ contains(fromJSON(steps.labels.outputs.output1), 'dependencies') || contains(fromJSON(steps.labels.outputs.output1), 'documentation') || contains(fromJSON(steps.labels.outputs.output1), 'duplicate') }}
+      run: |
+        cat  << EOF > comment.md
+        ## :rocket: Preview Deployment
+        Deployment skipped due to label(s) - dependencies, documentation, duplicate
+        EOF
+        gh pr comment ${{ github.event.number }} --body-file comment.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deployment:
     needs: checkLabels
     if: ${{ !(contains(fromJSON(needs.checkLabels.outputs.output1), 'dependencies') || contains(fromJSON(needs.checkLabels.outputs.output1), 'documentation') || contains(fromJSON(needs.checkLabels.outputs.output1), 'duplicate')) }}
@@ -56,15 +66,6 @@ jobs:
         cat  << EOF > comment.md
         ## :rocket: Preview Deployment
         [Preview Deployment](${{ steps.get_release_url.outputs.release_url }})
-        EOF
-        gh pr comment ${{ github.event.number }} --body-file comment.md
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Comment on PR
-      run: |
-        cat  << EOF > comment.md
-        ## :rocket: Preview Deployment
-        Deployment skipped due to label(s) - dependencies, documentation, duplicate
         EOF
         gh pr comment ${{ github.event.number }} --body-file comment.md
       env:

--- a/.github/workflows/VercelPreview.yaml
+++ b/.github/workflows/VercelPreview.yaml
@@ -9,7 +9,7 @@ jobs:
   checkLabels:
     runs-on: ubuntu-latest
     outputs:
-      output1: ${{ steps.labels.outputs.test }}
+      output1: ${{ steps.labels.outputs.json }}
     steps:
     - uses: actions/checkout@v4
     - name: Get PR labels

--- a/.github/workflows/VercelPreview.yaml
+++ b/.github/workflows/VercelPreview.yaml
@@ -23,7 +23,7 @@ jobs:
         json=$(gh pr view "$PR_NUMBER" --json labels | jq -c '.labels|map(.name)')
         echo "json=$json" >> "$GITHUB_OUTPUT"
     - name: Comment on PR
-      if: ${{ contains(fromJSON(steps.labels.outputs.output1), 'dependencies') || contains(fromJSON(steps.labels.outputs.output1), 'documentation') || contains(fromJSON(steps.labels.outputs.output1), 'duplicate') }}
+      if: ${{ contains(fromJSON(steps.labels.outputs.json), 'dependencies') || contains(fromJSON(steps.labels.outputs.json), 'documentation') || contains(fromJSON(steps.labels.outputs.json), 'duplicate') }}
       run: |
         cat  << EOF > comment.md
         ## :rocket: Preview Deployment

--- a/.github/workflows/VercelProduct.yaml
+++ b/.github/workflows/VercelProduct.yaml
@@ -15,7 +15,7 @@ jobs:
         - name: Install Vercel CLI
           run: npm install -g vercel
         - name: Link Vercel Project
-          run: vercel link --token=${{secrets.VERCEL_TOKEN}} --project ${{secrets.VERCEL_PROJECT}} --yes
+          run: vercel link --token=${{secrets.VERCEL_TOKEN}} --project ${{vars.VERCEL_PROJECT}} --yes
         - name: Deploy with Vercel
           run: vercel deploy --prod --token=${{secrets.VERCEL_TOKEN}} >deployment-url.txt 2>error.txt
         - name: Set release url


### PR DESCRIPTION
Enhance the deployment process by adding conditions based on PR labels, allowing for more controlled deployments. This prevents deployment for certain labels like 'dependencies', 'documentation', and 'duplicate'.