### PR TITLE
Potential fix for code scanning alert no. 1: Stored cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "remark-slug": "^7.0.1",
     "remark-toc": "^9.0.0",
     "swiper": "^11.2.1",
-    "tocbot": "^4.32.2"
+    "tocbot": "^4.32.2",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.5",

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-
+import escapeHtml from 'escape-html';
 import { Post } from '@/lib/posts';
 import { Button } from './button';
 
@@ -18,7 +18,7 @@ const PostCard = ({ dirname, slug, title, date, description }: PostCardProps) =>
                 <h2 className='text-xl'>{title}</h2><small className='content-end'>{date}</small>
             </div>
             <p className='text-sm mb-2'>{description}</p>
-            <Link href={`/${dirname}/${slug}`}>続きを読む</Link>
+            <Link href={`/${escapeHtml(dirname)}/${escapeHtml(slug)}`}>続きを読む</Link>
         </div>
     );
 };


### PR DESCRIPTION
Potential fix for [https://github.com/gakuseiBOT/HP/security/code-scanning/1](https://github.com/gakuseiBOT/HP/security/code-scanning/1)

To fix the stored cross-site scripting vulnerability, we need to sanitize the `slug` and `dirname` values before using them in the `href` attribute of the `Link` component. The best way to do this is to use a library like `escape-html` to ensure that any potentially malicious content is properly escaped.

1. Install the `escape-html` library.
2. Import the `escape-html` library in the relevant file.
3. Use the `escape-html` function to sanitize the `slug` and `dirname` values before using them in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
